### PR TITLE
Fix Langflow gateway reliability in EKS

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Configure the following in your GitHub repo:
 - **MONGO_PASS**
 - **MONGO_HOST**
 - **OPENAI_API_KEY** (optional)
+- **LANGFLOW_API_KEY** (optional, but may be required by newer Langflow auth defaults)
 
  The IAM role should trust GitHub's OIDC provider and allow:
  - `ecr:DescribeRepositories`, `ecr:CreateRepository` (for ephemeral accounts)
@@ -50,11 +51,28 @@ Configure the following in your GitHub repo:
  When `demo_mode=true`, the deployment uses `manifests/ingress-demo.yaml` (no host / no ACM cert) and prints a demo URL like:
  `http://<alb-dns-name>/`
 
+## Langflow API auth in Kubernetes
+
+Some Langflow versions return an HTML login page for API calls unless you pass an `x-api-key`.
+If your chatbot shows an error like `Unexpected token '<'`, create this secret so the FastAPI gateway can authenticate to the sidecar:
+
+```bash
+kubectl -n chatbot create secret generic langflow-api-key \
+  --from-literal=LANGFLOW_API_KEY='your-langflow-api-key'
+```
+
+Then restart the deployment:
+
+```bash
+kubectl -n chatbot rollout restart deploy/chatbot
+```
+
  ## Langflow seed image (ephemeral clusters)
  
  Since the entire cluster is ephemeral, Langflow's SQLite DB is seeded via an initContainer.
  Seeding is optional:
  - If you provide `langflow_seed_image`, the deployment seeds `/data/langflow.db` before Langflow starts.
+ - The init container also ensures `/data/langflow.db` is writable by the Langflow process after it is copied to the PVC.
  - If you omit it, Langflow will start with a fresh DB and you can build the flow in the running environment.
 
  ### Build the flow in EKS and export `langflow.db`

--- a/app/main.py
+++ b/app/main.py
@@ -14,6 +14,7 @@ MONGO_DB         = os.getenv("MONGO_DB", "stardb")
 MONGO_COLLECTION = os.getenv("MONGO_COLLECTION", "services")
 LANGFLOW_URL     = os.getenv("LANGFLOW_URL", "http://127.0.0.1:7860")
 FLOW_ID          = os.getenv("FLOW_ID", "REPLACE_WITH_YOUR_FLOW_ID")
+LANGFLOW_API_KEY = os.getenv("LANGFLOW_API_KEY", "")
 
 # Optional model overrides (set in ConfigMap if you want)
 LLM_NODE_ID = os.getenv("LLM_NODE_ID")       # e.g., "ChatOpenAI-abc123" from Langflow UI
@@ -99,6 +100,13 @@ def _model_tweaks(context_str: str) -> Dict[str, Any]:
     return tweaks
 
 
+def _langflow_headers() -> Dict[str, str]:
+    headers: Dict[str, str] = {}
+    if LANGFLOW_API_KEY:
+        headers["x-api-key"] = LANGFLOW_API_KEY
+    return headers
+
+
 # -------------------- Health & Data --------------------
 @app.get("/health")
 def health():
@@ -158,7 +166,7 @@ async def chat(req: ChatRequest):
         # ----- Call Langflow -----
         url = f"{LANGFLOW_URL}/api/v1/run/{FLOW_ID}?stream=false"
         async with httpx.AsyncClient(timeout=60.0) as http:
-            r = await http.post(url, json=payload)
+            r = await http.post(url, json=payload, headers=_langflow_headers())
 
         if r.status_code >= 400:
             raise HTTPException(status_code=502, detail=f"Langflow error: {r.text}")
@@ -197,8 +205,16 @@ class ValidateCodeRequest(BaseModel):
 async def validate_code(req: ValidateCodeRequest):
     url = f"{LANGFLOW_URL}/api/v1/validate/code"
     async with httpx.AsyncClient(timeout=30.0) as http:
-        r = await http.post(url, json=req.model_dump())
-        return r.json(), r.status_code
+        r = await http.post(url, json=req.model_dump(), headers=_langflow_headers())
+        try:
+            return r.json(), r.status_code
+        except Exception:
+            return {
+                "detail": "Langflow validator returned a non-JSON response.",
+                "status": r.status_code,
+                "content_type": r.headers.get("content-type"),
+                "body_snippet": r.text[:500],
+            }, r.status_code
 
 
 # -------------------- Minimal browser chat UI (GET /) --------------------
@@ -402,7 +418,14 @@ async function submit(){
       })
     });
 
-    const data = await r.json();
+    const contentType = (r.headers.get('content-type') || '').toLowerCase();
+    let data;
+    if (contentType.includes('application/json')) {
+      data = await r.json();
+    } else {
+      const text = await r.text();
+      throw new Error(`HTTP ${r.status}: ${text.slice(0, 300)}`);
+    }
     if(!r.ok) throw new Error(data.detail || JSON.stringify(data));
     pending.textContent = data.answer;
   } catch (err) {

--- a/manifests/deployment-noseed.yaml
+++ b/manifests/deployment-noseed.yaml
@@ -29,6 +29,13 @@ spec:
             name: chatbot-config
         - secretRef:
             name: starai-db-secret
+        env:
+        - name: LANGFLOW_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: langflow-api-key
+              key: LANGFLOW_API_KEY
+              optional: true
         readinessProbe:
           httpGet: { path: /health, port: http }
           initialDelaySeconds: 15

--- a/manifests/deployment.yaml
+++ b/manifests/deployment.yaml
@@ -29,6 +29,7 @@ spec:
           if [ ! -f /data/langflow.db ]; then
             cp /seed/langflow.db /data/langflow.db
           fi
+          chmod 664 /data/langflow.db
         volumeMounts:
         - name: langflow-data
           mountPath: /data
@@ -44,6 +45,13 @@ spec:
             name: chatbot-config
         - secretRef:
             name: starai-db-secret
+        env:
+        - name: LANGFLOW_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: langflow-api-key
+              key: LANGFLOW_API_KEY
+              optional: true
         readinessProbe:
           httpGet: { path: /health, port: http }
           initialDelaySeconds: 15


### PR DESCRIPTION
## Summary
- make the gateway handle Langflow API auth and non-JSON upstream responses more gracefully
- fix the seeded Langflow SQLite file permissions on startup so the sidecar can write to the PVC
- document the optional Langflow API key and seeded database permission behavior

## Validation
- verified python3 -m py_compile app/main.py
- verified the EKS deployment recovered and both gateway and Langflow became healthy
- verified the /health/deps, /api/services, and /chat paths from inside the running pod after MongoDB was deployed